### PR TITLE
ci: add github.event_name == 'workflow_dispatch' condition to release_framework

### DIFF
--- a/.github/workflows/release_framework.yml
+++ b/.github/workflows/release_framework.yml
@@ -24,11 +24,17 @@ on:
 jobs:
   release_framework:
     if: github.event_name == 'workflow_dispatch' || ((startsWith(github.head_ref, 'release') || startsWith(github.head_ref, 'prerelease')) && github.event.pull_request.merged == true)
+    environment: ENV
     runs-on: macos-latest
     steps:
 
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Set up Xcode
+      if: ${{ runner.environment != 'self-hosted' }}
+      run: sudo xcode-select -s /Applications/Xcode_${{ vars.XCODE_VERSION }}.app/Contents/Developer
+      shell: bash
 
     - name: Setup gem
       uses: appier/appier-ios-framework/.github/actions/install_gem_dependencies@master


### PR DESCRIPTION
## Purpose

Current condition cannot trigger `release_framework` by `workflow_dispatch`.
To manual trigger release process we need to add `github.event_name == 'workflow_dispatch'` to execute condition
