### PR TITLE
fix: properly handle GitHub Actions auto-skip in deployment job conditions

### DIFF
--- a/.github/workflows/release_framework.yml
+++ b/.github/workflows/release_framework.yml
@@ -82,7 +82,7 @@ jobs:
 
   deploy_pod_framework:
     needs: [prepare, create_release]
-    if: needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_framework && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')
+    if: !failure() && needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_framework && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -100,7 +100,7 @@ jobs:
 
   deploy_pod_extension:
     needs: [prepare, create_release]
-    if: needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_extension && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')
+    if: !failure() && needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_extension && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')
     runs-on: macos-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_framework.yml
+++ b/.github/workflows/release_framework.yml
@@ -82,7 +82,7 @@ jobs:
 
   deploy_pod_framework:
     needs: [prepare, create_release]
-    if: !failure() && needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_framework && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')
+    if: ${{ !failure() && needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_framework && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success') }}
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -100,7 +100,7 @@ jobs:
 
   deploy_pod_extension:
     needs: [prepare, create_release]
-    if: !failure() && needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_extension && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')
+    if: ${{ !failure() && needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_extension && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success') }}
     runs-on: macos-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Problem
When `create_release` job is skipped (e.g., on `workflow_dispatch` with `skip_add_tag_and_release=true`), GitHub Actions automatically skips all dependent jobs, even if they have custom `if` conditions that should override this behavior. This prevents independent deployments from running when release creation is intentionally skipped.

# Root Cause
GitHub Actions has an implicit auto-skip mechanism: if a job depends on another job that is skipped, the dependent job is automatically skipped regardless of its `if` condition. This is a safety feature to prevent dependent jobs from running in unexpected states, but it doesn't allow override via custom conditions alone.

# Solution
Add `!failure()` status check function to the beginning of deployment job conditions. This explicitly tells GitHub Actions to evaluate the custom condition logic even when dependencies are skipped.

### How It Works
- `!failure()` - Allows evaluation to proceed even if dependencies are skipped
- `(github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')` - Allows manual dispatch to 

**Before:**
```yaml
if: needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_framework && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success')
```

**After:**
```yaml
if: ${{ !failure() && needs.prepare.outputs.should_release == 'true' && !inputs.skip_deploy_pod_framework && (github.event_name == 'workflow_dispatch' || needs.create_release.result == 'success') }}
```

### Changes
- Updated `deploy_pod_framework ` and `deploy_pod_framework` job condition
- Wrapped conditions with `${{ }}` for clarity and to silence YAML linter

# Testing
You may use branch `michael/fix-cd-steps-rerunable-test` for testing and here is an [execution record](https://github.com/appier/appier-ios-framework/actions/runs/20943451270)